### PR TITLE
Add an LSpace.fork method, which replaces the current LSpace

### DIFF
--- a/lib/lspace.rb
+++ b/lib/lspace.rb
@@ -65,7 +65,7 @@ class LSpace
   # Update the LSpace-variable with the given name.
   #
   # Bear in mind that any code using this LSpace will see this change, and consider
-  # using {LSpace.with} instead to localize your changes.
+  # using {LSpace.with} or {LSpace.fork} instead to localize your changes.
   #
   # This method is mostly useful for setting up a new LSpace before any code is
   # using it, and has no effect on parent LSpaces.

--- a/lib/lspace/class_methods.rb
+++ b/lib/lspace/class_methods.rb
@@ -76,6 +76,18 @@ class LSpace
     self.current = previous
   end
 
+  # Replace the current LSpace with a fork of it.
+  #
+  # Forking the Lspace means that values changed with LSpace#[]= no
+  # longer affect parent LSpaces.
+  #
+  # This should be used carefully - it may confuse around_filters,
+  # since they will see a different LSpace after the block is called
+  # than before.
+  def self.fork
+    self.current = LSpace.new({}, self.current)
+  end
+
   # Create a closure that will re-enter the current LSpace when the block is called.
   #
   # @example

--- a/spec/class_method_spec.rb
+++ b/spec/class_method_spec.rb
@@ -82,6 +82,30 @@ describe LSpace do
     end
   end
 
+  describe ".fork" do
+    it "should not propagate variable changes to the parent LSpace" do
+      LSpace.enter(@lspace) do
+        LSpace.fork
+        LSpace[:foo] = 5
+        LSpace[:foo].should == 5
+      end
+      LSpace[:foo].should be_nil
+    end
+
+    it "should show the new forked LSpace to around_filters after returning" do
+      @lspace.around_filter do |&block|
+        LSpace[:foo].should == 4
+        block.call
+        LSpace[:foo].should == 5
+      end
+      @lspace[:foo] = 4
+      @lspace.enter do
+        LSpace.fork
+        LSpace[:foo] = 5
+      end
+    end
+  end
+
   describe ".preserve" do
     it "should delegate to LSpace.current" do
       LSpace.current.should_receive(:wrap).once


### PR DESCRIPTION
Loosely, this is intended for situations where you want to use
LSpace.[]=, but don't want those changes to propagate to your caller
or to other blocks bound to your own LSpace.

The interaction with around_filters is a bit messy, though fairly easy
to describe. I've written a test case to capture the current behavior,
though I don't actually know whether or not it's desirable, but I also
don't know what you'd do instead.
