### PR TITLE
LSpace#hierarchy: Cache the list of parent lspaces.

### DIFF
--- a/lib/lspace.rb
+++ b/lib/lspace.rb
@@ -136,10 +136,12 @@ class LSpace
   #
   # @return [Array<LSpace>]
   def hierarchy
-    if parent
-      [self] + parent.hierarchy
-    else
-      [self]
+    @hierarchy ||= begin
+                     if parent
+                       [self] + parent.hierarchy
+                     else
+                       [self]
+                     end
     end
   end
 end


### PR DESCRIPTION
Prior to this change, in a profile of a large, LSpace-intensive app,
we spent nearly 10% of our time walking the LSpace hierarchy.
