### PR TITLE
Add LSpace wrapper for Fiber

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Operation safety
 
 LSpace is thread-safe, so entering a new LSpace on one thread won't affect any of the
 other Threads. In addition, LSpace also comes with extensions for
-[eventmachine](https://github.com/eventmachine/eventmachine) and
-[celluloid](http://celluloid.io/) which extends the notion of thread-safety to
+[eventmachine](https://github.com/eventmachine/eventmachine),
+[celluloid](http://celluloid.io/), and fiber which extends the notion of thread-safety to
 operation-safety.
 
 This means that even if you're doing multiple things on one thread, or one thing using
@@ -64,6 +64,14 @@ end
 ```
 
 See also [examples/celluloid.rb](https://github.com/ConradIrwin/lspace/tree/master/examples/celluloid.rb).
+
+
+```ruby
+require 'lspace/fiber'
+LSpace.with(:user_id => 5) do
+  Fiber.new { LSpace[:user_id] == 5 }.resume
+end
+```
 
 `lspace_reader`
 ===============

--- a/lib/lspace/fiber.rb
+++ b/lib/lspace/fiber.rb
@@ -1,0 +1,3 @@
+class << Fiber
+  in_lspace :new
+end

--- a/spec/class_method_spec.rb
+++ b/spec/class_method_spec.rb
@@ -74,12 +74,6 @@ describe LSpace do
         Thread.new{ LSpace.current.should_not == @lspace }.join
       end
     end
-
-    it "should not effect other fibers" do
-      LSpace.enter(@lspace) do
-        Fiber.new{ LSpace.current.should_not == @lspace }.resume
-      end
-    end
   end
 
   describe ".fork" do

--- a/spec/fiber_spec.rb
+++ b/spec/fiber_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe LSpace do
+  it "should be preserved across Fiber resumes" do
+    LSpace.with(:foo => 2) do
+      $fiber = Fiber.new do
+        $foo = LSpace[:foo]
+      end
+    end
+    $fiber.resume
+    $foo.should == 2
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require_relative '../lib/lspace'
 require_relative '../lib/lspace/eventmachine'
 require_relative '../lib/lspace/celluloid'
+require_relative '../lib/lspace/fiber'
 require_relative '../lib/lspace/rspec'
 require 'pry-rescue/rspec'


### PR DESCRIPTION
Fiber needs an LSpace wrapper to work. Add a convenience file for it.

r? @ConradIrwin 
CC @ebroder 