### PR TITLE
Add license to gemspec

### DIFF
--- a/lspace.gemspec
+++ b/lspace.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.description = "Provides the convenience of global variables, without the safety concerns."
   s.files = `git ls-files`.split("\n")
   s.require_path = "lib"
+  s.license = "MIT"
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'pry-rescue'


### PR DESCRIPTION
https://github.com/ConradIrwin/lspace/blob/master/LICENSE.MIT
There's a license file for MIT license, so here we explicitly tell rubygems about its license.